### PR TITLE
Add authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,5 @@ Find all the red dragons
 🙅 Not officially affiliated or endorsed by Wizards of the Coast or Magic the Gathering
 
 🙇‍♂️ Thanks to MTGJSON for their free data https://mtgjson.com/downloads/all-files/
+
+🎁 Thanks to Andrew Gioia for his excellent mana & keyrune packages https://github.com/andrewgioia/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Save them into the `/app/database` folder and run the seeder `artisan db:seed St
 
 The project includes [GraphIQL](https://github.com/mll-lab/laravel-graphiql). You can make use of the client by installing Composer `dev` dependencies and then visiting http://localhost/graphiql.
 
+### Authentication
+
+The `/graphql` endpoint is secured with a Laravel Sanctum token auth. You will need to login and generate a token, and send this token with your requests as the Authorization header.
+
+```http request
+Authorization: Bearer <your-token>
+```
+
 ### Example queries
 
 Get all the cards, but only a few fields, paginated by 20 per page on page 4, and include the set the card belongs to.

--- a/app/Livewire/CardIndex.php
+++ b/app/Livewire/CardIndex.php
@@ -30,7 +30,7 @@ class CardIndex extends Component implements HasForms, HasTable
                 TextColumn::make('name')
                     ->sortable()
                     ->searchable()
-                    ->url(fn ($record) => 'https://scryfall.com/search?q=' . urlencode($record->name), true),
+                    ->url(fn ($record) => 'https://scryfall.com/search?q='.urlencode($record->name), true),
                 TextColumn::make('types')
                     ->sortable()
                     ->searchable(),

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "filament/tables": "^3.2",
         "laravel/framework": "^11.41.3",
         "laravel/jetstream": "^5.3.4",
-        "laravel/sanctum": "^4.0.8",
+        "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
         "livewire/livewire": "^3.5.19",
         "nuwave/lighthouse": "^6.49.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c93149b4b45c20d8afea0506034ce532",
+    "content-hash": "4150f92b2620aa9bd966c6f6474b436d",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/config/graphiql.php
+++ b/config/graphiql.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Routes configuration
+    |--------------------------------------------------------------------------
+    |
+    | Set the key as URI at which the GraphiQL UI can be viewed,
+    | and add any additional configuration for the route.
+    |
+    | You can add multiple routes pointing to different GraphQL endpoints.
+    |
+    */
+
+    'routes' => [
+        '/graphiql' => [
+            'name' => 'graphiql',
+            'middleware' => ['web'],
+            // 'prefix' => '',
+            // 'domain' => 'graphql.' . env('APP_DOMAIN', 'localhost'),
+
+            /*
+            |--------------------------------------------------------------------------
+            | Default GraphQL endpoint
+            |--------------------------------------------------------------------------
+            |
+            | The default endpoint that the GraphiQL UI is set to.
+            | It assumes you are running GraphQL on the same domain
+            | as GraphiQL, but can be set to any URL.
+            |
+            */
+
+            'endpoint' => '/graphql',
+
+            /*
+            |--------------------------------------------------------------------------
+            | Subscription endpoint
+            |--------------------------------------------------------------------------
+            |
+            | The default subscription endpoint the GraphiQL UI uses to connect to.
+            | Tries to connect to the `endpoint` value if `null` as ws://{{endpoint}}
+            |
+            | Example: `ws://your-endpoint` or `wss://your-endpoint`
+            |
+            */
+
+            'subscription-endpoint' => env('GRAPHIQL_SUBSCRIPTION_ENDPOINT', null),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Control GraphiQL availability
+    |--------------------------------------------------------------------------
+    |
+    | Control if the GraphiQL UI is accessible at all.
+    | This allows you to disable it in certain environments,
+    | for example you might not want it active in production.
+    |
+    */
+
+    'enabled' => env('GRAPHIQL_ENABLED', true),
+];

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -60,7 +60,7 @@ return [
     'features' => [
         // Features::termsAndPrivacyPolicy(),
         // Features::profilePhotos(),
-        // Features::api(),
+        Features::api(),
         // Features::teams(['invitations' => true]),
         Features::accountDeletion(),
     ],

--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -31,17 +33,23 @@ return [
          */
         'middleware' => [
             // Ensures the request is not vulnerable to cross-site request forgery.
-            // Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
+            Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
 
             // Always set the `Accept: application/json` header.
             Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,
 
             // Logs in a user if they are authenticated. In contrast to Laravel's 'auth'
             // middleware, this delegates auth and permission checks to the field level.
-            Nuwave\Lighthouse\Http\Middleware\AttemptAuthentication::class,
+            // Nuwave\Lighthouse\Http\Middleware\AttemptAuthentication::class,
 
             // Logs every incoming GraphQL query.
             // Nuwave\Lighthouse\Http\Middleware\LogGraphQLQueries::class,
+
+            // Use Sanctum to check tokens
+            'auth:sanctum',
+
+            // Use the middleware to get the tokens
+            EnsureFrontendRequestsAreStateful::class,
         ],
 
         /*
@@ -63,7 +71,7 @@ return [
     |
     */
 
-    'guards' => null,
+    'guards' => ['sanctum'],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -48,6 +48,9 @@ return [
             // Use Sanctum to check tokens
             'auth:sanctum',
 
+            // Add api middleware
+            'api',
+
             // Use the middleware to get the tokens
             EnsureFrontendRequestsAreStateful::class,
         ],

--- a/resources/views/vendor/graphiql/index.blade.php
+++ b/resources/views/vendor/graphiql/index.blade.php
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+@php use MLL\GraphiQL\DownloadAssetsCommand; @endphp
+<head>
+    <meta charset=utf-8/>
+    <meta name="viewport"
+          content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <title>GraphiQL</title>
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden;
+        }
+
+        #graphiql {
+            height: 100vh;
+        }
+
+        /* Make the explorer feel more integrated */
+        .docExplorerWrap {
+            overflow: auto !important;
+            width: 100% !important;
+            height: auto !important;
+        }
+
+        .doc-explorer-title-bar {
+            font-weight: var(--font-weight-medium);
+            font-size: var(--font-size-h2);
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .doc-explorer-rhs {
+            display: none;
+        }
+
+        .doc-explorer-contents {
+            margin: var(--px-16) 0 0;
+        }
+
+        .graphiql-explorer-actions select {
+            margin-left: var(--px-12);
+        }
+    </style>
+    <script src="{{ DownloadAssetsCommand::reactPath() }}"></script>
+    <script src="{{ DownloadAssetsCommand::reactDOMPath() }}"></script>
+    <link rel="stylesheet" href="{{ DownloadAssetsCommand::cssPath() }}"/>
+    <link rel="shortcut icon" href="{{ DownloadAssetsCommand::faviconPath() }}"/>
+
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+</head>
+
+<body>
+
+<div id="graphiql">Loading...</div>
+<script src="{{ DownloadAssetsCommand::jsPath() }}"></script>
+<script src="{{ DownloadAssetsCommand::pluginExplorerPath() }}"></script>
+<script>
+    const fetcher = GraphiQL.createFetcher({
+        url: '{{ $url }}',
+        subscriptionUrl: '{{ $subscriptionUrl }}',
+    });
+
+    function GraphiQLWithExplorer() {
+        const [query, setQuery] = React.useState('');
+
+        return React.createElement(GraphiQL, {
+            fetcher,
+            query,
+            onEditQuery: setQuery,
+            defaultEditorToolsVisibility: true,
+            plugins: [
+                GraphiQLPluginExplorer.useExplorerPlugin({
+                    query,
+                    onEdit: setQuery,
+                }),
+            ],
+            defaultHeaders: JSON.stringify({
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+            })
+            // See https://github.com/graphql/graphiql/tree/main/packages/graphiql#props for available settings
+        });
+    }
+
+    ReactDOM.render(
+        React.createElement(GraphiQLWithExplorer),
+        document.getElementById('graphiql'),
+    );
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add authentication to the graphql api, so users will now need to login a create a Sanctum token and pass it with requests.